### PR TITLE
When generating version file, enable matching non-annotated tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2021-12-09
+### Adds
+- When generating version file, enable matching non-annotated tags
+
 ## [0.12.0] - 2021-11-29
 ### Adds
 - Add broadcast channel as input option, add dispatch action when characters are entered, update to Slack Go API v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.0] - 2021-12-09
-### Adds
+## [0.13.0] - 2021-12-14
+### Updates
 - When generating version file, enable matching non-annotated tags
+- Slack does not yet allow users to create reminders recurring more often than once a day, so just create one that runs daily 30 min after the incident has been declared
+- Include year in Slack channel name to decrease chance of having name creation conflicts and to make the name more explicit
 
 ## [0.12.0] - 2021-11-29
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.0] - 2021-12-14
+## [0.13.0] - 2021-12-22
 ### Updates
 - When generating version file, enable matching non-annotated tags
 - Slack does not yet allow users to create reminders recurring more often than once a day, so just create one that runs daily 30 min after the incident has been declared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When generating version file, enable matching non-annotated tags
 - Slack does not yet allow users to create reminders recurring more often than once a day, so just create one that runs daily 30 min after the incident has been declared
 - Include year in Slack channel name to decrease chance of having name creation conflicts and to make the name more explicit
+- Describe incidents according to severity and impact
 
 ## [0.12.0] - 2021-11-29
 ### Adds

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -201,9 +201,9 @@ func (h *botHandler) cmdIncident(ctx context.Context, w http.ResponseWriter, cmd
 	}
 	channelIDs := []string{}
 	for i := range channels {
-		channelIDs = append(channelIDs, fmt.Sprintf("<#%s>", channels[i].ID))
+		channelIDs = append(channelIDs, channels[i].ID)
 	}
-	botChannels := createOptionBlockObjects(channelIDs)
+	botChannels := createOptionBlockObjects(channelIDs, "channel")
 	broadcastChOption := slack.NewOptionsSelectBlockElement(slack.OptTypeStatic, nil, "broadcast_channel", botChannels...)
 	initialChannel := fmt.Sprintf("<#%s>", h.opts.BroadcastChannelID)
 	initialChannelLabel := slack.NewTextBlockObject(slack.PlainTextType, initialChannel, false, false)
@@ -298,7 +298,7 @@ func (h *botHandler) cmdIncident(ctx context.Context, w http.ResponseWriter, cmd
 		w.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
-	envOptions := createOptionBlockObjects(envs)
+	envOptions := createOptionBlockObjects(envs, "")
 	envOptionsBlock := slack.NewCheckboxGroupsBlockElement("incident_environment_affected", envOptions...)
 	environmentBlock := slack.NewInputBlock("incident_environment_affected", envTxt, envOptionsBlock)
 
@@ -314,7 +314,7 @@ func (h *botHandler) cmdIncident(ctx context.Context, w http.ResponseWriter, cmd
 		w.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
-	regionOptions := createOptionBlockObjects(regions)
+	regionOptions := createOptionBlockObjects(regions, "")
 	regionOptionsBlock := slack.NewCheckboxGroupsBlockElement("incident_region_affected", regionOptions...)
 	regionBlock := slack.NewInputBlock("incident_region_affected", regionTxt, regionOptionsBlock)
 
@@ -433,9 +433,9 @@ func (h *botHandler) cmdResolveIncident(ctx context.Context, w http.ResponseWrit
 	}
 	channelIDs := []string{}
 	for i := range channels {
-		channelIDs = append(channelIDs, fmt.Sprintf("<#%s>", channels[i].ID))
+		channelIDs = append(channelIDs, channels[i].ID)
 	}
-	botChannels := createOptionBlockObjects(channelIDs)
+	botChannels := createOptionBlockObjects(channelIDs, "channel")
 	broadcastChOption := slack.NewOptionsSelectBlockElement(slack.OptTypeStatic, nil, "broadcast_channel", botChannels...)
 	initialChannel := fmt.Sprintf("<#%s>", h.opts.BroadcastChannelID)
 	initialChannelLabel := slack.NewTextBlockObject(slack.PlainTextType, initialChannel, false, false)
@@ -487,7 +487,7 @@ func (h *botHandler) cmdResolveIncident(ctx context.Context, w http.ResponseWrit
 			DefaultMessage: &i18n.Message{
 				ID:    "No",
 				Other: "No"},
-		})})
+		})}, "")
 	archiveOptionsBlock := slack.NewRadioButtonsBlockElement("archive_choice", archiveOptions...)
 	archiveBlock := slack.NewInputBlock("archive_choice", archiveTxt, archiveOptionsBlock)
 
@@ -532,11 +532,20 @@ func (h *botHandler) cmdResolveIncident(ctx context.Context, w http.ResponseWrit
 	return nil
 }
 
+type OptionType struct {
+}
+
 // createOptionBlockObjects - utility function for generating option block objects
-func createOptionBlockObjects(options []string) []*slack.OptionBlockObject {
+func createOptionBlockObjects(options []string, optionType string) []*slack.OptionBlockObject {
 	optionBlockObjects := make([]*slack.OptionBlockObject, 0, len(options))
+	var text string
 	for _, o := range options {
-		optionText := slack.NewTextBlockObject(slack.PlainTextType, o, false, false)
+		if optionType == "channel" {
+			text = fmt.Sprintf("<#%s>", o)
+		} else {
+			text = o
+		}
+		optionText := slack.NewTextBlockObject(slack.PlainTextType, text, false, false)
 		optionBlockObjects = append(optionBlockObjects, slack.NewOptionBlockObject(o, optionText, nil))
 	}
 	return optionBlockObjects

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -205,10 +205,9 @@ func (h *botHandler) cmdIncident(ctx context.Context, w http.ResponseWriter, cmd
 	}
 	botChannels := createOptionBlockObjects(channelIDs, "channel")
 	broadcastChOption := slack.NewOptionsSelectBlockElement(slack.OptTypeStatic, nil, "broadcast_channel", botChannels...)
-	initialChannel := fmt.Sprintf("<#%s>", h.opts.BroadcastChannelID)
-	initialChannelLabel := slack.NewTextBlockObject(slack.PlainTextType, initialChannel, false, false)
-	initialChannelOptionBlockObject := slack.NewOptionBlockObject(initialChannel, initialChannelLabel, nil)
-	broadcastChOption.InitialOption = initialChannelOptionBlockObject
+	initialChannelLabel := slack.NewTextBlockObject(slack.PlainTextType,
+		fmt.Sprintf("<#%s>", h.opts.BroadcastChannelID), false, false)
+	broadcastChOption.InitialOption = slack.NewOptionBlockObject(h.opts.BroadcastChannelID, initialChannelLabel, nil)
 	broadcastChBlock := slack.NewInputBlock("broadcast_channel", broadcastChLabel, broadcastChOption)
 	broadcastChBlock.Hint = slack.NewTextBlockObject(slack.PlainTextType,
 		h.opts.Localizer.MustLocalize(&i18n.LocalizeConfig{
@@ -530,9 +529,6 @@ func (h *botHandler) cmdResolveIncident(ctx context.Context, w http.ResponseWrit
 
 	w.WriteHeader(http.StatusOK)
 	return nil
-}
-
-type OptionType struct {
 }
 
 // createOptionBlockObjects - utility function for generating option block objects

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -436,10 +436,9 @@ func (h *botHandler) cmdResolveIncident(ctx context.Context, w http.ResponseWrit
 	}
 	botChannels := createOptionBlockObjects(channelIDs, "channel")
 	broadcastChOption := slack.NewOptionsSelectBlockElement(slack.OptTypeStatic, nil, "broadcast_channel", botChannels...)
-	initialChannel := fmt.Sprintf("<#%s>", h.opts.BroadcastChannelID)
-	initialChannelLabel := slack.NewTextBlockObject(slack.PlainTextType, initialChannel, false, false)
-	initialChannelOptionBlockObject := slack.NewOptionBlockObject(initialChannel, initialChannelLabel, nil)
-	broadcastChOption.InitialOption = initialChannelOptionBlockObject
+	initialChannelLabel := slack.NewTextBlockObject(slack.PlainTextType,
+		fmt.Sprintf("<#%s>", h.opts.BroadcastChannelID), false, false)
+	broadcastChOption.InitialOption = slack.NewOptionBlockObject(h.opts.BroadcastChannelID, initialChannelLabel, nil)
 	broadcastChBlock := slack.NewInputBlock("broadcast_channel", broadcastChLabel, broadcastChOption)
 	broadcastChBlock.Hint = slack.NewTextBlockObject(slack.PlainTextType,
 		h.opts.Localizer.MustLocalize(&i18n.LocalizeConfig{

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -171,7 +171,6 @@ func (h *botHandler) cmdIncident(ctx context.Context, w http.ResponseWriter, cmd
 			DefaultMessage: &i18n.Message{
 				ID:    "IncidentCreationDescription",
 				Other: "This will create a new incident Slack channel, and notify about the incident in a broadcast channel. This incident response system is based on the Incident Command System."},
-			TemplateData: map[string]string{"broadcastChannel": fmt.Sprintf("<#%s>", h.opts.BroadcastChannelID)},
 		}), false, false)
 	contextBlock := slack.NewContextBlock("context", contextText)
 
@@ -402,7 +401,6 @@ func (h *botHandler) cmdResolveIncident(ctx context.Context, w http.ResponseWrit
 			DefaultMessage: &i18n.Message{
 				ID:    "ResolveIncidentDescription",
 				Other: "This will resolve an incident and notify about the resolution in a broadcast channel"},
-			TemplateData: map[string]string{"broadcastChannel": fmt.Sprintf("<#%s>", h.opts.BroadcastChannelID)},
 		}), false, false)
 	contextBlock := slack.NewContextBlock("context", contextText)
 

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -141,6 +141,19 @@ func TestCreateOptionBlockObjects(t *testing.T) {
 			Value: "b",
 			URL:   ""}),
 	}, optionBlockObjects)
+
+	options = []string{"ID1", "ID2"}
+	optionBlockObjects = createOptionBlockObjects(options, "channel")
+	assert.Equal(t, []*slack.OptionBlockObject{
+		(&slack.OptionBlockObject{
+			Text:  &slack.TextBlockObject{Type: "plain_text", Text: "<#ID1>", Emoji: false, Verbatim: false},
+			Value: "ID1",
+			URL:   ""}),
+		(&slack.OptionBlockObject{
+			Text:  &slack.TextBlockObject{Type: "plain_text", Text: "<#ID2>", Emoji: false, Verbatim: false},
+			Value: "ID2",
+			URL:   ""}),
+	}, optionBlockObjects)
 }
 
 type dummyClient struct {

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -126,11 +126,11 @@ func TestHandleCommand(t *testing.T) {
 
 func TestCreateOptionBlockObjects(t *testing.T) {
 	options := []string{}
-	optionBlockObjects := createOptionBlockObjects(options)
+	optionBlockObjects := createOptionBlockObjects(options, "")
 	assert.Empty(t, optionBlockObjects)
 
 	options = []string{"a", "b"}
-	optionBlockObjects = createOptionBlockObjects(options)
+	optionBlockObjects = createOptionBlockObjects(options, "")
 	assert.Equal(t, []*slack.OptionBlockObject{
 		(&slack.OptionBlockObject{
 			Text:  &slack.TextBlockObject{Type: "plain_text", Text: "a", Emoji: false, Verbatim: false},

--- a/bot/interactive.go
+++ b/bot/interactive.go
@@ -305,9 +305,20 @@ func (h *botHandler) doIncidentTasks(ctx context.Context, params *inputParams, i
 	// Add channel reminder about updating progress
 	// Need to use user access token since bot token is not allowed token type: https://api.slack.com/methods/reminders.add
 	userSlackClient := slack.New(h.opts.UserAccessToken)
+	user, err := h.slackClient.GetUserInfoContext(ctx, params.incidentDeclarer)
+	if err != nil {
+		log.Error().Err(err).Send()
+		return
+	}
+	loc, err := time.LoadLocation(user.TZ)
+	if err != nil {
+		log.Error().Err(err).Send()
+		return
+	}
+	now := time.Now().In(loc)
 	if _, err := userSlackClient.AddChannelReminder(incidentChannel.ID,
 		fmt.Sprintf("\"Reminder for IC <@%s>: Update progress about the incident every 30 min in <#%s>, or remove the reminder and archive the channel if the incident is resolved\"", params.incidentCommander, params.broadcastChannel),
-		fmt.Sprintf("every day at %s", time.Now().Local().Add(time.Minute*time.Duration(30)).Format("03:04:05PM"))); err != nil {
+		fmt.Sprintf("every day at %s", now.Add(time.Minute*time.Duration(30)).Format("03:04:05PM"))); err != nil {
 		if sendErr := h.sendMessage(ctx, incidentChannel.ID, slack.MsgOptionPostEphemeral(params.incidentDeclarer),
 			slack.MsgOptionText(fmt.Sprintf("Failed to add channel reminder: %s", err.Error()), false)); sendErr != nil {
 			log.Error().Err(sendErr).Msg(sendError)

--- a/bot/interactive.go
+++ b/bot/interactive.go
@@ -307,7 +307,7 @@ func (h *botHandler) doIncidentTasks(ctx context.Context, params *inputParams, i
 	userSlackClient := slack.New(h.opts.UserAccessToken)
 	if _, err := userSlackClient.AddChannelReminder(incidentChannel.ID,
 		fmt.Sprintf("\"Reminder for IC <@%s>: Update progress about the incident every 30 min in <#%s>, or remove the reminder and archive the channel if the incident is resolved\"", params.incidentCommander, params.broadcastChannel),
-		fmt.Sprintf("every day at %s", time.Now().Local().Add(time.Minute * time.Duration(30)).Format("03:04:05PM"))); err != nil {
+		fmt.Sprintf("every day at %s", time.Now().Local().Add(time.Minute*time.Duration(30)).Format("03:04:05PM"))); err != nil {
 		if sendErr := h.sendMessage(ctx, incidentChannel.ID, slack.MsgOptionPostEphemeral(params.incidentDeclarer),
 			slack.MsgOptionText(fmt.Sprintf("Failed to add channel reminder: %s", err.Error()), false)); sendErr != nil {
 			log.Error().Err(sendErr).Msg(sendError)

--- a/bot/interactive.go
+++ b/bot/interactive.go
@@ -306,8 +306,8 @@ func (h *botHandler) doIncidentTasks(ctx context.Context, params *inputParams, i
 	// Need to use user access token since bot token is not allowed token type: https://api.slack.com/methods/reminders.add
 	userSlackClient := slack.New(h.opts.UserAccessToken)
 	if _, err := userSlackClient.AddChannelReminder(incidentChannel.ID,
-		fmt.Sprintf("Reminder for IC <@%s>: Update progress about the incident in <#%s>", params.incidentCommander, params.broadcastChannel),
-		"Every 30 min"); err != nil {
+		fmt.Sprintf("\"Reminder for IC <@%s>: Update progress about the incident every 30 min in <#%s>, or remove the reminder and archive the channel if the incident is resolved\"", params.incidentCommander, params.broadcastChannel),
+		fmt.Sprintf("every day at %s", time.Now().Local().Add(time.Minute * time.Duration(30)).Format("03:04:05PM"))); err != nil {
 		if sendErr := h.sendMessage(ctx, incidentChannel.ID, slack.MsgOptionPostEphemeral(params.incidentDeclarer),
 			slack.MsgOptionText(fmt.Sprintf("Failed to add channel reminder: %s", err.Error()), false)); sendErr != nil {
 			log.Error().Err(sendErr).Msg(sendError)
@@ -409,7 +409,7 @@ func postErrorResponse(ctx context.Context, verr map[string]string, w http.Respo
 
 // createChannelName - create incident channel name based on input field
 func createChannelName(s string) string {
-	return fmt.Sprintf("inc_%s_%s", s, strings.ToLower(time.Now().Format("Jan2")))
+	return fmt.Sprintf("inc_%s_%s", s, strings.ToLower(time.Now().Format("2Jan2006")))
 }
 
 // createUserFriendlyConversationError - Map https://api.slack.com/methods/conversations.create error codes to user friendly messages

--- a/cmd/devopsbot/main.go
+++ b/cmd/devopsbot/main.go
@@ -104,6 +104,8 @@ func initConfig(cmd *cobra.Command) func() {
 		_ = viper.BindEnv("incidentDocTemplateURL", "incidentDocTemplateURL")
 		_ = viper.BindEnv("incident.environments", "incident.environments")
 		_ = viper.BindEnv("incident.regions", "incident.regions")
+		_ = viper.BindEnv("incident.severityLevels", "incident.severityLevels")
+		_ = viper.BindEnv("incident.impactLevels", "incident.impactLevels")
 		_ = viper.BindEnv("addr", "addr")
 		_ = viper.BindEnv(tlsAddr, tlsAddr)
 		_ = viper.BindEnv(tlsCert, tlsCert)
@@ -165,6 +167,8 @@ func newCmd() *cobra.Command {
 				IncidentDocTemplateURL: cfg.IncidentDocTemplateURL,
 				IncidentEnvs:           cfg.IncidentEnvs,
 				IncidentRegions:        cfg.IncidentRegions,
+				IncidentSeverityLevels: cfg.IncidentSeverityLevels,
+				IncidentImpactLevels:   cfg.IncidentImpactLevels,
 			}
 			log.Debug().Msgf("opts: %#v", opts)
 

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,8 @@ type Config struct {
 
 	IncidentEnvs           string
 	IncidentRegions        string
+	IncidentSeverityLevels string
+	IncidentImpactLevels   string
 	IncidentDocTemplateURL string
 }
 
@@ -42,6 +44,8 @@ func FromViper(v *viper.Viper) (Config, error) {
 
 	c.IncidentEnvs = v.GetString("incident.environments")
 	c.IncidentRegions = v.GetString("incident.regions")
+	c.IncidentSeverityLevels = v.GetString("incident.severityLevels")
+	c.IncidentImpactLevels = v.GetString("incident.impactLevels")
 	c.IncidentDocTemplateURL = v.GetString("incidentDocTemplateURL")
 
 	return c, nil

--- a/docs/src/GETTING_STARTED.md
+++ b/docs/src/GETTING_STARTED.md
@@ -206,6 +206,16 @@ spec:
                 configMapKeyRef:
                   key: incident.regions
                   name: devopsbot-settings
+            - name: incident.severityLevels
+              valueFrom:
+                configMapKeyRef:
+                  key: incident.severityLevels
+                  name: devopsbot-settings
+            - name: incident.impactLevels
+              valueFrom:
+                configMapKeyRef:
+                  key: incident.impactLevels
+                  name: devopsbot-settings
             - name: addr
               valueFrom:
                 configMapKeyRef:

--- a/docs/src/GETTING_STARTED.md
+++ b/docs/src/GETTING_STARTED.md
@@ -56,6 +56,18 @@ data:
       "eu-west-1",
       "us-east-1"
     ]
+  incident.severityLevels: |-
+    [
+      "high",
+      "medium",
+      "low"
+    ]
+  incident.impactLevels: |-
+    [
+      "high",
+      "medium",
+      "low"
+    ]
   server.prometheusNamespace: devopsbot
   tls.addr: :3443
   tls.cert: /var/devopsbot/tls.crt

--- a/gen_version.sh
+++ b/gen_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-if (git describe --abbrev=0 --exact-match &>/dev/null); then
+if (git describe --abbrev=0 --tags --exact-match &>/dev/null); then
   # If we are on a tagged commit, use that tag as version
-  git describe --abbrev=0 --exact-match | sed 's/v\(.*\)/\1/'
+  git describe --abbrev=0 --tags --exact-match | sed 's/v\(.*\)/\1/'
 else
   # Otherwise get the latest tagged commit
   tag=$(git rev-list --tags --max-count=1 2>/dev/null)


### PR DESCRIPTION
Updates:
- When generating version file, enable matching non-annotated tags
- Slack does not yet allow users to create reminders recurring more often than once a day, so just create one that runs daily 30 min after the incident has been declared
- Include year in Slack channel name to decrease chance of having name creation conflicts and to make the name more explicit
- When defining an incident, define it according to severity and impact